### PR TITLE
feat(UI): add Super‑Admin dashboard and enhance admin pages

### DIFF
--- a/src/components/admin/SideBar.tsx
+++ b/src/components/admin/SideBar.tsx
@@ -3,7 +3,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useRouter } from 'next/router';
 import { useAppDispatch } from '@/store/hooks';
 import { logout } from '@/store/slices/authSlice';
-import {LayoutDashboard,Users,Home,CalendarCheck,Star,Settings,} from 'lucide-react';
+import {LayoutDashboard,Users,Home,CalendarCheck,Star,Settings, ShieldCheck,} from 'lucide-react';
 
 interface SidebarProps {
   isOpen: boolean;
@@ -13,10 +13,12 @@ interface SidebarProps {
 const mainLinks = [
   { href: '/admin', label: 'Dashboard', icon: LayoutDashboard },
   { href: '/admin/users', label: 'Users', icon: Users },
+   { href: '/admin/super-admin', label: 'Super Admins', icon: ShieldCheck }, 
   { href: '/admin/landlord-requests', label: 'Landlord Requests', icon: Users },
   { href: '/admin/properties', label: 'Properties', icon: Home },
   { href: '/admin/bookings', label: 'Bookings', icon: CalendarCheck },
   { href: '/admin/reviews', label: 'Reviews', icon: Star },
+ 
 ];
 
 const settingsLink = { href: '/admin/settings', label: 'Settings', icon: Settings };

--- a/src/pages/admin/bookings.tsx
+++ b/src/pages/admin/bookings.tsx
@@ -1,11 +1,7 @@
 import { NextPage } from 'next';
 import { useEffect, useState, useCallback } from 'react';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
-import {
-  fetchBookings,
-  updateBookingStatus,
-  Booking,
-} from '@/store/slices/adminSlice';
+import {fetchBookings,updateBookingStatus,Booking,} from '@/store/slices/adminSlice';
 import toast from 'react-hot-toast';
 import Head from 'next/head';
 import AdminLayout from '@/components/admin/AdminLayout';
@@ -14,15 +10,9 @@ import socket, { connectSocket } from '@/utils/socket';
 const PAGE_SIZE = 5;
 
 const AdminBookingsPage: NextPage = () => {
-  const dispatch = useAppDispatch();
-  const {
-    bookings,
-    bookingsPage,
-    bookingsTotalPages,
-    loading,
-    error,
-  } = useAppSelector((state) => state.admin)!;
 
+  const dispatch = useAppDispatch();
+  const {bookings,bookingsPage,bookingsTotalPages,loading,error,} = useAppSelector((state) => state.admin)!;
   const [page, setPage] = useState(bookingsPage);
   const [updatingIds, setUpdatingIds] = useState<Record<string, boolean>>({});
 

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -13,10 +13,14 @@ const AdminDashboardPage: NextPage = () => {
 
   const dispatch = useAppDispatch();
   const { user } = useAppSelector((s) => s.auth)!;
-  const { metrics, loading, error } = useAppSelector((s) => s.admin)!;
+  const { metrics, loading, error } = useAppSelector((s) => s.admin);
 
   useEffect(() => {
-    if (user?.role !== 'ADMIN') return;
+    if (user?.role !== 'ADMIN'){
+      if (user?.role !== 'SUPER_ADMIN') {
+        return;
+      }
+    };
     dispatch(fetchMetrics());
     const token = localStorage.getItem('token') || '';
     connectSocket(token);

--- a/src/pages/admin/landlord-requests.tsx
+++ b/src/pages/admin/landlord-requests.tsx
@@ -1,28 +1,26 @@
 import { NextPage } from 'next';
 import { useEffect, useState } from 'react';
 import Image from 'next/image';
-import {
-  fetchLandlordRequests,
-  approveLandlordRequest,
-  rejectLandlordRequest,
-  clearLandlordRequestError,
-  LandlordRequest,
-} from '@/store/slices/landlordRequestSlice';
+import {fetchLandlordRequests,approveLandlordRequest,rejectLandlordRequest,clearLandlordRequestError,LandlordRequest,} from '@/store/slices/landlordRequestSlice';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import AdminLayout from '@/components/admin/AdminLayout';
 import toast from 'react-hot-toast';
+import { Loader } from 'lucide-react';
+
+const STATUSES: Array<'PENDING'|'APPROVED'|'REJECTED'> = ['PENDING','APPROVED','REJECTED'];
+const LIMIT = 5;
 
 const AdminLandlordRequestsPage: NextPage = () => {
-  const dispatch = useAppDispatch();
-  const [page, setPage] = useState<number>(1);
-  const limit = 5;
 
-  const { requests, loading, error, totalPages, totalRequests } =
-    useAppSelector((state) => state.landlordRequests);
+  const dispatch = useAppDispatch();
+  const [page, setPage] = useState(1);
+  const [status, setStatus] = useState<'PENDING'|'APPROVED'|'REJECTED'>('PENDING');
+
+  const {requests,loading,error,totalPages,totalRequests,} = useAppSelector((state) => state.landlordRequests);
 
   useEffect(() => {
-    dispatch(fetchLandlordRequests({ page, limit }));
-  }, [dispatch, page]);
+    dispatch(fetchLandlordRequests({ page, limit: LIMIT, status }));
+  }, [dispatch, page, status]);
 
   useEffect(() => {
     if (error) {
@@ -35,12 +33,10 @@ const AdminLandlordRequestsPage: NextPage = () => {
     try {
       await dispatch(approveLandlordRequest(userId)).unwrap();
       toast.success('Application approved');
-      if (requests.length === 1 && page > 1) {
-        setPage((prev) => prev - 1);
-      }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Failed to approve';
-      toast.error(message);
+      if (requests.length === 1 && page > 1) setPage(page - 1);
+      else dispatch(fetchLandlordRequests({ page, limit: LIMIT, status }));
+    } catch {
+      toast.error('Failed to approve');
     }
   };
 
@@ -50,29 +46,43 @@ const AdminLandlordRequestsPage: NextPage = () => {
     try {
       await dispatch(rejectLandlordRequest({ userId, reason })).unwrap();
       toast.success('Application rejected');
-      if (requests.length === 1 && page > 1) {
-        setPage((prev) => prev - 1);
-      }
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : 'Failed to reject';
-      toast.error(message);
+      if (requests.length === 1 && page > 1) setPage(page - 1);
+      else dispatch(fetchLandlordRequests({ page, limit: LIMIT, status }));
+    } catch {
+      toast.error('Failed to reject');
     }
   };
 
   return (
     <AdminLayout>
       <h1 className="text-2xl font-bold mb-6">Landlord Applications</h1>
+      <div className="mb-4 flex space-x-2">
+        {STATUSES.map((s) => (
+          <button
+            key={s}
+            onClick={() => { setStatus(s); setPage(1); }}
+            className={`px-4 py-2 rounded ${
+              status === s
+                ? 'bg-blue-600 text-white'
+                : 'bg-gray-200 text-gray-700 hover:bg-gray-300'
+            }`}
+          >
+            {s[0] + s.slice(1).toLowerCase()}
+          </button>
+        ))}
+      </div>
 
       {loading ? (
         <div className="flex justify-center py-10">
-          <div className="animate-spin h-8 w-8 border-4 border-blue-600 border-t-transparent rounded-full" />
+          <Loader className="animate-spin h-10 w-10 text-blue-600" />
         </div>
       ) : requests.length === 0 ? (
-        <p className="text-gray-600">No applications found.</p>
+        <p className="text-gray-600">No {status.toLowerCase()} applications.</p>
       ) : (
         <>
           <p className="mb-4 text-sm text-gray-700">
-            Showing {requests.length} of {totalRequests} applications
+            Showing {requests.length} of {totalRequests}{' '}
+            {status.toLowerCase()} applications
           </p>
 
           <div className="space-y-6">
@@ -107,10 +117,7 @@ const AdminLandlordRequestsPage: NextPage = () => {
 
                 <div className="mt-4 grid grid-cols-2 gap-4">
                   {req.landlordDocs.map((doc) => (
-                    <div
-                      key={doc.id}
-                      className="border rounded overflow-hidden"
-                    >
+                    <div key={doc.id} className="border rounded overflow-hidden">
                       <Image
                         src={doc.url}
                         alt={doc.docType}
@@ -122,25 +129,30 @@ const AdminLandlordRequestsPage: NextPage = () => {
                     </div>
                   ))}
                 </div>
-
-                <div className="mt-4 flex space-x-2">
-                  <button
-                    onClick={() => handleApprove(req.id)}
-                    className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
-                  >
-                    Approve
-                  </button>
-                  <button
-                    onClick={() => handleReject(req.id)}
-                    className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-                  >
-                    Reject
-                  </button>
-                </div>
+                {status === 'PENDING' && (
+                  <div className="mt-4 flex space-x-2">
+                    <button
+                      onClick={() => handleApprove(req.id)}
+                      className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700"
+                    >
+                      Approve
+                    </button>
+                    <button
+                      onClick={() => handleReject(req.id)}
+                      className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
+                    >
+                      Reject
+                    </button>
+                  </div>
+                )}
+                {status !== 'PENDING' && (
+                  <p className="mt-4 text-sm italic text-gray-600">
+                    {status.toLowerCase()}
+                  </p>
+                )}
               </div>
             ))}
           </div>
-
           <div className="flex items-center justify-between mt-6 px-4 py-3 bg-blue-600 rounded-lg">
             <button
               onClick={() => setPage((p) => Math.max(p - 1, 1))}

--- a/src/pages/admin/profile.tsx
+++ b/src/pages/admin/profile.tsx
@@ -3,16 +3,13 @@ import { NextPage } from "next";
 import Head from "next/head";
 import Image from "next/image";
 import { useRouter } from "next/router";
-import {
-  fetchCurrentProfile,
-  saveProfile,
-  clearError,
-} from "@/store/slices/authSlice";
+import {fetchCurrentProfile,saveProfile,clearError,} from "@/store/slices/authSlice";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import toast from "react-hot-toast";
 import AdminLayout from "@/components/admin/AdminLayout";
 
 const ProfilePage: NextPage = () => {
+
   const dispatch = useAppDispatch();
   const router = useRouter();
   const { user, status: fetchStatus, error: fetchError } = useAppSelector(
@@ -26,7 +23,6 @@ const ProfilePage: NextPage = () => {
   const [saving, setSaving] = useState(false);
   const [nameError, setNameError] = useState("");
 
-  // Redirect if not logged in
   useEffect(() => {
     if (user === null) {
       router.replace(
@@ -41,7 +37,6 @@ const ProfilePage: NextPage = () => {
     dispatch(fetchCurrentProfile());
   }, [dispatch]);
 
-  // Populate form when user data arrives
   useEffect(() => {
     if (user) {
       setName(user.name);

--- a/src/pages/admin/properties.tsx
+++ b/src/pages/admin/properties.tsx
@@ -1,7 +1,6 @@
+import React, { Fragment, useEffect, useState } from 'react';
 import { NextPage } from 'next';
-import { useEffect, useState } from 'react';
 import axios from 'axios';
-import api from '@/utils/api';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {fetchProperties,deletePropertyByAdmin,approveProperty,rejectProperty,} from '@/store/slices/adminSlice';
 import AdminLayout from '@/components/admin/AdminLayout';
@@ -9,7 +8,7 @@ import toast from 'react-hot-toast';
 import Head from 'next/head';
 import socket, { connectSocket } from '@/utils/socket';
 import { Loader } from 'lucide-react';
-import { motion} from 'framer-motion';
+import { AnimatePresence, motion } from 'framer-motion';
 import Image from 'next/image';
 
 interface PropertyDetail {
@@ -17,51 +16,32 @@ interface PropertyDetail {
   title: string;
   description: string;
   city: string;
-  rentPerMonth: string | number;
+  rentPerMonth: number;
   numBedrooms: number;
   numBathrooms: number;
   propertyType: string;
   amenities: string[];
   status: 'PENDING' | 'APPROVED' | 'REJECTED';
-  rejectionReason?: string | null;
+  rejectionReason?: string;
   createdAt: string;
   landlord: { id: string; name: string; email: string };
   images: { id: string; url: string }[];
 }
 
-const tabVariants = {
-  hidden: { opacity: 0, y: 10 },
-  visible: { opacity: 1, y: 0 },
-};
-
 const AdminPropertiesPage: NextPage = () => {
+
   const dispatch = useAppDispatch();
-  const {
-    properties,
-    propertiesPage,
-    propertiesLimit,
-    propertiesTotalPages,
-    loading,
-  } = useAppSelector((s) => s.admin)!;
+  const {properties,propertiesPage,propertiesLimit,propertiesTotalPages,loading,} = useAppSelector((s) => s.admin);
 
-  const [exporting, setExporting] = useState(false);
-  const [showRejectModal, setShowRejectModal] = useState(false);
-  const [rejectReason, setRejectReason] = useState('');
-  const [propertyToReject, setPropertyToReject] = useState<string | null>(null);
-
-  const [showDetailModal, setShowDetailModal] = useState(false);
-  const [detailLoading, setDetailLoading] = useState(false);
-  const [propertyDetail, setPropertyDetail] = useState<PropertyDetail | null>(null);
-  const [activeTab, setActiveTab] = useState<'overview' | 'images'>('overview');
-
+  const [expandedId, setExpandedId] = useState<string | null>(null);
   useEffect(() => {
     const token = localStorage.getItem('token');
     if (token) connectSocket(token);
 
+    dispatch(fetchProperties({ page: propertiesPage, limit: propertiesLimit }));
+
     const reload = () =>
       dispatch(fetchProperties({ page: propertiesPage, limit: propertiesLimit }));
-    reload();
-
     socket.on('listing:approved', reload);
     socket.on('listing:rejected', reload);
     socket.on('listing:pending', reload);
@@ -71,29 +51,6 @@ const AdminPropertiesPage: NextPage = () => {
       socket.off('listing:pending', reload);
     };
   }, [dispatch, propertiesPage, propertiesLimit]);
-
-  const handleExport = async () => {
-    setExporting(true);
-    try {
-      const res = await api.get('/api/properties/export', {
-        responseType: 'blob',
-      });
-      const blob = new Blob([res.data], { type: res.headers['content-type'] });
-      const url = window.URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = 'rentify-properties.xlsx';
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      window.URL.revokeObjectURL(url);
-      toast.success('Properties exported successfully');
-    } catch {
-      toast.error('Failed to export properties');
-    } finally {
-      setExporting(false);
-    }
-  };
 
   const handleApprove = (id: string) =>
     dispatch(approveProperty(id))
@@ -109,47 +66,13 @@ const AdminPropertiesPage: NextPage = () => {
       .catch((e) => toast.error(e));
   };
 
-  const openRejectModal = (id: string) => {
-    setPropertyToReject(id);
-    setRejectReason('');
-    setShowRejectModal(true);
-  };
-  const closeRejectModal = () => {
-    setShowRejectModal(false);
-    setPropertyToReject(null);
-    setRejectReason('');
-  };
-  const submitReject = () => {
-    if (!rejectReason.trim() || !propertyToReject) {
-      return toast.error('Enter a reason');
-    }
-    dispatch(
-      rejectProperty({ propertyId: propertyToReject, reason: rejectReason.trim() })
-    )
+  const handleReject = (id: string) => {
+    const reason = prompt('Enter rejection reason:');
+    if (!reason) return;
+    dispatch(rejectProperty({ propertyId: id, reason }))
       .unwrap()
-      .then(() => {
-        toast.success('Rejected');
-        closeRejectModal();
-      })
+      .then(() => toast.success('Rejected'))
       .catch((e) => toast.error(e));
-  };
-
-  const openDetailModal = async (id: string) => {
-    setDetailLoading(true);
-    try {
-      const { data } = await axios.get<PropertyDetail>(`/api/properties/${id}`);
-      setPropertyDetail(data);
-      setActiveTab('overview');
-      setShowDetailModal(true);
-    } catch {
-      toast.error('Failed to fetch details');
-    } finally {
-      setDetailLoading(false);
-    }
-  };
-  const closeDetailModal = () => {
-    setShowDetailModal(false);
-    setPropertyDetail(null);
   };
 
   const prev = () =>
@@ -164,124 +87,81 @@ const AdminPropertiesPage: NextPage = () => {
       <Head>
         <title>Rentify | Manage Properties</title>
       </Head>
-      <div className="flex flex-col space-y-6 px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 bg-blue-600 rounded-lg space-y-4 sm:space-y-0">
-          <h1 className="text-xl sm:text-2xl font-bold text-white">
-            Manage Properties
-          </h1>
-          <button
-            onClick={handleExport}
-            disabled={exporting || properties.length === 0}
-            aria-busy={exporting}
-            className={`flex justify-center items-center px-4 py-2 rounded text-white w-full sm:w-auto transition ${
-              exporting || properties.length === 0
-                ? 'bg-green-400 cursor-not-allowed'
-                : 'bg-green-600 hover:bg-green-700'
-            }`}
-          >
-            {exporting ? <Loader className="animate-spin mr-2 h-4 w-4" /> : null}
-            {exporting ? 'Exporting…' : 'Export Properties'}
-          </button>
-        </div>
-        {loading && (
+
+      <div className="p-4 space-y-4">
+        <h1 className="text-2xl font-bold">Manage Properties</h1>
+        {loading ? (
           <div className="flex justify-center py-10">
             <Loader className="animate-spin h-12 w-12 text-blue-600" />
           </div>
-        )}
-        {!loading && properties.length === 0 && (
-          <p className="text-gray-600">No properties found.</p>
-        )}
-        {!loading && properties.length > 0 && (
-          <>
-            <div className="overflow-x-auto rounded-lg shadow-sm">
-              <table className="min-w-full divide-y divide-gray-200 bg-white text-gray-900">
-                <thead className="bg-blue-600 sticky top-0">
-                  <tr>
-                    {['Title', 'City', 'Rent', 'Status', 'Created', 'Actions'].map(
-                      (h) => (
-                        <th
-                          key={h}
-                          className="px-4 py-2 text-left text-sm font-medium text-white"
-                        >
-                          {h}
-                        </th>
-                      )
-                    )}
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-200">
-                  {properties.map((p) => (
-                    <tr key={p.id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3 whitespace-nowrap text-sm font-medium">
-                        {p.title}
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-sm">
-                        {p.city}
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-sm">
-                        {Number(p.rentPerMonth).toFixed(2).replace(/\.00/, '')}Birr/month
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-sm">
-                        <span
-                          className={`px-2 py-1 rounded text-xs font-semibold ${
-                            p.status === 'APPROVED'
-                              ? 'bg-green-100 text-green-800'
-                              : p.status === 'REJECTED'
-                              ? 'bg-red-100 text-red-800'
-                              : 'bg-yellow-100 text-yellow-800'
-                          }`}
-                        >
-                          {p.status}
-                        </span>
-                        {p.status === 'REJECTED' && p.rejectionReason && (
-                          <p className="text-xs text-gray-500 mt-1">
-                            Reason: {p.rejectionReason}
-                          </p>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-sm">
+        ) : (
+          <div className="overflow-x-auto bg-white rounded shadow">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead className="bg-blue-600">
+                <tr>
+                  {['Title', 'City', 'Rent', 'Status', 'Created', '⋯'].map((h) => (
+                    <th
+                      key={h}
+                      className="px-4 py-2 text-left text-sm font-medium text-white"
+                    >
+                      {h}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {properties.map((p) => (
+                  <Fragment key={p.id}>
+                    <tr
+                      className="hover:bg-gray-50 cursor-pointer"
+                      onClick={() =>
+                        setExpandedId(expandedId === p.id ? null : p.id)
+                      }
+                    >
+                      <td className="px-4 py-2 text-sm">{p.title}</td>
+                      <td className="px-4 py-2 text-sm">{p.city}</td>
+                        <td className="px-4 py-2 text-sm">
+                          {(() => {
+                            const rentNum = typeof p.rentPerMonth === 'string'
+                              ? parseFloat(p.rentPerMonth)
+                              : Number(p.rentPerMonth);
+                            return rentNum.toFixed(0);    
+                            })()} ETB
+                          </td>
+                      <td className="px-4 py-2 text-sm">{p.status}</td>
+                      <td className="px-4 py-2 text-sm">
                         {new Date(p.createdAt).toLocaleDateString()}
                       </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-center text-sm space-x-1">
-                        {p.status === 'PENDING' && (
-                          <button
-                            onClick={() => handleApprove(p.id)}
-                            className="px-3 py-1 rounded text-white bg-green-600 hover:bg-green-700 text-xs"
-                          >
-                            Approve
-                          </button>
-                        )}
-                        {p.status === 'PENDING' && (
-                          <button
-                            onClick={() => openRejectModal(p.id)}
-                            className="px-3 py-1 rounded text-white bg-yellow-600 hover:bg-yellow-700 text-xs"
-                          >
-                            Reject
-                          </button>
-                        )}
-                        <button
-                          onClick={() => handleDelete(p.id)}
-                          className="px-3 py-1 rounded text-white bg-red-600 hover:bg-red-700 text-xs"
-                        >
-                          Delete
-                        </button>
-                        <button
-                          onClick={() => openDetailModal(p.id)}
-                          className="px-3 py-1 rounded text-white bg-blue-600 hover:bg-blue-700 text-xs"
-                        >
-                          View
-                        </button>
-                      </td>
+                      <td className="px-4 py-2 text-center text-sm">▶</td>
                     </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-            <div className="flex flex-col sm:flex-row items-center justify-between px-4 py-3 bg-blue-600 rounded-b-lg space-y-2 sm:space-y-0">
+                    <AnimatePresence initial={false}>
+                      {expandedId === p.id && (
+                        <motion.tr
+                          initial={{ opacity: 0, height: 0 }}
+                          animate={{ opacity: 1, height: 'auto' }}
+                          exit={{ opacity: 0, height: 0 }}
+                          transition={{ duration: 0.2 }}
+                        >
+                          <td colSpan={6} className="px-4 py-3 bg-gray-50">
+                            <PropertyDetailsRow
+                              propertyId={p.id}
+                              onApprove={() => handleApprove(p.id)}
+                              onReject={() => handleReject(p.id)}
+                              onDelete={() => handleDelete(p.id)}
+                            />
+                          </td>
+                        </motion.tr>
+                      )}
+                    </AnimatePresence>
+                  </Fragment>
+                ))}
+              </tbody>
+            </table>
+            <div className="flex items-center justify-between p-3 bg-blue-600 text-white">
               <button
                 onClick={prev}
                 disabled={propertiesPage <= 1}
-                className={`px-3 py-1 rounded text-white font-medium transition focus:outline-none focus:ring-2 focus:ring-white ${
+                className={`px-3 py-1 rounded ${
                   propertiesPage <= 1
                     ? 'bg-blue-400 cursor-not-allowed'
                     : 'bg-blue-800 hover:bg-blue-700'
@@ -289,13 +169,13 @@ const AdminPropertiesPage: NextPage = () => {
               >
                 Previous
               </button>
-              <span className="text-white text-sm">
+              <span>
                 Page {propertiesPage} of {propertiesTotalPages}
               </span>
               <button
                 onClick={next}
                 disabled={propertiesPage >= propertiesTotalPages}
-                className={`px-3 py-1 rounded text-white font-medium transition focus:outline-none focus:ring-2 focus:ring-white ${
+                className={`px-3 py-1 rounded ${
                   propertiesPage >= propertiesTotalPages
                     ? 'bg-blue-400 cursor-not-allowed'
                     : 'bg-blue-800 hover:bg-blue-700'
@@ -303,135 +183,6 @@ const AdminPropertiesPage: NextPage = () => {
               >
                 Next
               </button>
-            </div>
-          </>
-        )}
-
-        {showRejectModal && (
-          <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50">
-            <div className="bg-white rounded-lg p-6 w-96">
-              <h2 className="text-lg font-semibold mb-4">Reject Property</h2>
-              <textarea
-                value={rejectReason}
-                onChange={(e) => setRejectReason(e.target.value)}
-                rows={4}
-                placeholder="Enter rejection reason"
-                className="w-full p-2 border rounded resize-none"
-              />
-              <div className="mt-4 flex justify-end space-x-3">
-                <button
-                  onClick={closeRejectModal}
-                  className="px-4 py-2 rounded border hover:bg-gray-100"
-                >
-                  Cancel
-                </button>
-                <button
-                  onClick={submitReject}
-                  className="px-4 py-2 rounded bg-yellow-600 text-white hover:bg-yellow-700"
-                >
-                  Submit
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-        {showDetailModal && propertyDetail && (
-          <div className="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50 p-4">
-            <div className="bg-white rounded-lg w-full max-w-3xl overflow-hidden">
-              <div className="flex border-b">
-                {(['overview', 'images'] as const).map((tab) => (
-                  <button
-                    key={tab}
-                    onClick={() => setActiveTab(tab)}
-                    className={`flex-1 text-center py-3 font-medium ${
-                      activeTab === tab
-                        ? 'border-b-2 border-blue-600 text-blue-600'
-                        : 'text-gray-500 hover:text-gray-700'
-                    }`}
-                  >
-                    {tab === 'overview' ? 'Overview' : 'Images'}
-                  </button>
-                ))}
-              </div>
-              <div className="p-6">
-                {detailLoading ? (
-                  <p>Loading details…</p>
-                ) : activeTab === 'overview' ? (
-                  <motion.div
-                    key="overview"
-                    variants={tabVariants}
-                    initial="hidden"
-                    animate="visible"
-                    exit="hidden"
-                    transition={{ duration: 0.2 }}
-                    className="space-y-4"
-                  >
-                    <h2 className="text-2xl font-bold">{propertyDetail.title}</h2>
-                    <p className="text-gray-700">{propertyDetail.description}</p>
-                    <ul className="grid grid-cols-2 gap-4 text-sm text-gray-600">
-                      <li><strong>City:</strong> {propertyDetail.city}</li>
-                      <li>
-                        <strong>Rent/month:</strong> $
-                        {Number(propertyDetail.rentPerMonth).toFixed(2).replace(/\.00$/, '')}Birr/month
-                      </li>
-                      <li><strong>Bedrooms:</strong> {propertyDetail.numBedrooms}</li>
-                      <li><strong>Bathrooms:</strong> {propertyDetail.numBathrooms}</li>
-                      <li><strong>Type:</strong> {propertyDetail.propertyType}</li>
-                      <li><strong>Amenities:</strong> {propertyDetail.amenities.join(', ')}</li>
-                      {propertyDetail.status === 'REJECTED' && propertyDetail.rejectionReason && (
-                        <li className="col-span-2 text-red-600">
-                          <strong>Rejection Reason:</strong> {propertyDetail.rejectionReason}
-                        </li>
-                      )}
-                      <li className="col-span-2">
-                        <strong>Listed On:</strong> {new Date(propertyDetail.createdAt).toLocaleDateString()}
-                      </li>
-                      <li className="col-span-2 bg-gray-50 p-4 rounded">
-                        <h3 className="font-semibold">Landlord</h3>
-                        <p>{propertyDetail.landlord.name}</p>
-                        <p>{propertyDetail.landlord.email}</p>
-                      </li>
-                    </ul>
-                  </motion.div>
-                ) : (
-                  <motion.div
-                    key="images"
-                    variants={tabVariants}
-                    initial="hidden"
-                    animate="visible"
-                    exit="hidden"
-                    transition={{ duration: 0.2 }}
-                  >
-                    {propertyDetail.images.length > 0 ? (
-                      <div className="grid grid-cols-3 gap-4">
-                        {propertyDetail.images.map((img) => (
-                          <div
-                            key={img.id}
-                            className="relative w-full h-48 bg-gray-100 rounded overflow-hidden"
-                          >
-                            <Image
-                              src={img.url}
-                              alt={propertyDetail.title}
-                              fill
-                              className="object-cover"
-                            />
-                          </div>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="text-gray-500">No images available.</p>
-                    )}
-                  </motion.div>
-                )}
-              </div>
-              <div className="border-t p-4 text-right">
-                <button
-                  onClick={closeDetailModal}
-                  className="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400"
-                >
-                  Close
-                </button>
-              </div>
             </div>
           </div>
         )}
@@ -441,3 +192,93 @@ const AdminPropertiesPage: NextPage = () => {
 };
 
 export default AdminPropertiesPage;
+
+function PropertyDetailsRow({
+  propertyId,
+  onApprove,
+  onReject,
+  onDelete,
+}: {
+  propertyId: string;
+  onApprove(): void;
+  onReject(): void;
+  onDelete(): void;
+}) {
+  const [detail, setDetail] = useState<PropertyDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    axios
+      .get<PropertyDetail>(`/api/properties/${propertyId}`)
+      .then((r) => setDetail(r.data))
+      .catch(() => toast.error('Failed to load details'))
+      .finally(() => setLoading(false));
+  }, [propertyId]);
+
+  if (loading || !detail) {
+    return (
+      <div className="py-4 text-center text-gray-500">
+        {loading ? 'Loading details…' : 'No details available'}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex space-x-4">
+        {detail.images.slice(0, 3).map((img) => (
+          <div
+            key={img.id}
+            className="relative w-1/3 h-32 rounded overflow-hidden"
+          >
+            <Image src={img.url} alt="" fill className="object-cover" />
+          </div>
+        ))}
+      </div>
+      <p className="text-gray-700">{detail.description}</p>
+      <ul className="grid grid-cols-2 gap-4 text-sm text-gray-600">
+        <li>
+          <strong>Bedrooms:</strong> {detail.numBedrooms}
+        </li>
+        <li>
+          <strong>Bathrooms:</strong> {detail.numBathrooms}
+        </li>
+        <li>
+          <strong>Type:</strong> {detail.propertyType}
+        </li>
+        <li>
+          <strong>Amenities:</strong> {detail.amenities.join(', ')}
+        </li>
+        <li className="col-span-2">
+          <strong>Landlord:</strong> {detail.landlord.name} (
+          {detail.landlord.email})
+        </li>
+      </ul>
+      <div className="flex space-x-2">
+        {detail.status === 'PENDING' && (
+          <>
+            <button
+              onClick={onApprove}
+              className="px-3 py-1 bg-green-600 text-white rounded hover:bg-green-700"
+            >
+              Approve
+            </button>
+            <button
+              onClick={onReject}
+              className="px-3 py-1 bg-yellow-600 text-white rounded hover:bg-yellow-700"
+            >
+              Reject
+            </button>
+          </>
+        )}
+        <button
+          onClick={onDelete}
+          className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700"
+        >
+          Delete
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/admin/super-admin.tsx
+++ b/src/pages/admin/super-admin.tsx
@@ -1,0 +1,274 @@
+'use client';
+import { NextPage } from 'next';
+import Head from 'next/head';
+import { useEffect, useState } from 'react';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import {fetchAdmins,createAdmin,deleteAdmin,clearAdminError,} from '@/store/slices/adminSlice';
+import toast from 'react-hot-toast';
+import AdminLayout from '@/components/admin/AdminLayout';
+import { Loader } from 'lucide-react';
+import { debounce } from '@/utils/debounce';
+import type { User } from '@/store/slices/adminSlice';
+
+const PAGE_LIMIT = 5;
+
+const SuperAdminPage: NextPage = () => {
+  
+  const dispatch = useAppDispatch();
+  const { user } = useAppSelector((s) => s.auth)!;
+  const {admins,loading,error,saPage: page,saTotalPages,} = useAppSelector((state) => state.admin);
+  const [search, setSearch] = useState('');
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    password: '',
+  });
+
+  useEffect(() => {
+      if (user?.role !== 'SUPER_ADMIN') {
+        toast.error('You do not have permission to access this page.');
+        window.location.href = '/admin/';
+        return;
+      }
+  })
+
+  useEffect(() => {
+    dispatch(fetchAdmins({ page, limit: PAGE_LIMIT }));
+  }, [dispatch, page]);
+
+  const onSearch = debounce((...args: unknown[]) => {
+    setSearch(String(args[0] ?? ''));
+  }, 500);
+
+  const filtered = admins.filter((u) =>
+    u.email.toLowerCase().includes(search.toLowerCase())
+  );
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setCreating(true);
+    const res = await dispatch(createAdmin(formData));
+    setCreating(false);
+    if (createAdmin.fulfilled.match(res)) {
+      toast.success('Admin created');
+      setFormData({ name: '', email: '', password: '' });
+      dispatch(fetchAdmins({ page, limit: PAGE_LIMIT }));
+    } else {
+      toast.error(res.payload as string);
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    setDeletingId(id);
+    const res = await dispatch(deleteAdmin(id));
+    setDeletingId(null);
+    if (deleteAdmin.fulfilled.match(res)) {
+      toast.success('Deleted');
+      dispatch(fetchAdmins({ page, limit: PAGE_LIMIT }));
+    } else {
+      toast.error(res.payload as string);
+    }
+  };
+
+  const handlePrev = () => {
+    if (page > 1) dispatch(fetchAdmins({ page: page - 1, limit: PAGE_LIMIT }));
+  };
+  const handleNext = () => {
+    if (page < saTotalPages)
+      dispatch(fetchAdmins({ page: page + 1, limit: PAGE_LIMIT }));
+  };
+
+  return (
+    <AdminLayout>
+      <Head>
+        <title>Rentify | Manage Admins</title>
+        <meta name="description" content="Super‑admin management dashboard" />
+      </Head>
+
+      <div className="flex flex-col space-y-6 px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 bg-blue-600 rounded-lg">
+          <h1 className="text-xl sm:text-2xl font-bold text-white">
+            Manage Admins
+          </h1>
+          <div className="flex items-center space-x-2 w-full sm:w-auto mt-2 sm:mt-0">
+            <input
+              type="text"
+              placeholder="Search by name or email..."
+              onChange={(e) => onSearch(e.target.value)}
+              className="flex-grow px-3 py-2 rounded border border-gray-300 focus:ring-2 focus:ring-blue-400 focus:outline-none w-full sm:w-64"
+            />
+            <button
+              className="btn btn-sm btn-outline text-white"
+              onClick={() => {
+                setSearch('');
+                dispatch(clearAdminError());
+              }}
+            >
+              Clear
+            </button>
+          </div>
+        </div>
+
+        {error && <p className="text-red-500">Error: {error}</p>}
+        <form onSubmit={handleCreate} className="space-y-4">
+          <div className="flex flex-col sm:flex-row gap-4">
+            <input
+              required
+              type="text"
+              placeholder="Name"
+              value={formData.name}
+              onChange={(e) =>
+                setFormData({ ...formData, name: e.target.value })
+              }
+              className="input input-bordered w-full"
+            />
+            <input
+              required
+              type="email"
+              placeholder="Email"
+              value={formData.email}
+              onChange={(e) =>
+                setFormData({ ...formData, email: e.target.value })
+              }
+              className="input input-bordered w-full"
+            />
+            <input
+              required
+              type="password"
+              placeholder="Password"
+              value={formData.password}
+              onChange={(e) =>
+                setFormData({ ...formData, password: e.target.value })
+              }
+              className="input input-bordered w-full"
+            />
+          </div>
+          <button
+            type="submit"
+            disabled={creating}
+            className="btn btn-primary"
+          >
+            {creating ? <Loader className="animate-spin mr-2 h-4 w-4" /> : 'Create Admin'}
+          </button>
+        </form>
+        {loading ? (
+          <div className="flex justify-center py-10">
+            <Loader className="animate-spin h-12 w-12 text-blue-600" />
+          </div>
+        ) : (
+          <div className="overflow-x-auto rounded-lg shadow-sm">
+            <table className="min-w-full divide-y divide-gray-200 bg-white text-gray-900">
+              <thead className="bg-blue-600 sticky top-0">
+                <tr>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-white">
+                    Name
+                  </th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-white hidden md:table-cell">
+                    Email
+                  </th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-white">
+                    Role
+                  </th>
+                  <th className="px-4 py-2 text-left text-sm font-medium text-white">
+                    Joined
+                  </th>
+                  <th className="px-4 py-2 text-center text-sm font-medium text-white">
+                    Actions
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-200">
+                {filtered.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="px-4 py-6 text-center text-gray-600"
+                    >
+                      No super‑admins found.
+                    </td>
+                  </tr>
+                ) : (
+                  filtered.map((u: User) => (
+                    <tr key={u.id} className="hover:bg-gray-50">
+                      <td className="px-4 py-3 whitespace-nowrap text-sm font-medium">
+                        {u.name}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-sm hidden md:table-cell">
+                        <a
+                          href={`mailto:${u.email}`}
+                          className="text-blue-600 hover:underline"
+                        >
+                          {u.email}
+                        </a>
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-sm">
+                        ADMIN
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-sm">
+                        {new Date(u.createdAt).toLocaleDateString()}
+                      </td>
+                      <td className="px-4 py-3 whitespace-nowrap text-center text-sm">
+                        <button
+                          onClick={() => handleDelete(u.id)}
+                          disabled={deletingId === u.id}
+                          className={`px-3 py-1 rounded text-white font-medium transition focus:outline-none focus:ring-2 focus:ring-red-500 ${
+                            deletingId === u.id
+                              ? 'bg-red-200 cursor-not-allowed'
+                              : 'bg-red-500 hover:bg-red-600'
+                          }`}
+                        >
+                          {deletingId === u.id ? (
+                            <Loader className="animate-spin h-4 w-4 mx-auto" />
+                          ) : (
+                            'Delete'
+                          )}
+                        </button>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {/* Pagination */}
+        {filtered.length > 0 && !loading && !error && (
+          <div className="flex flex-col sm:flex-row items-center justify-between px-4 py-3 bg-blue-600 rounded-b-lg space-y-2 sm:space-y-0">
+            <button
+              onClick={handlePrev}
+              disabled={page <= 1}
+              className={`px-3 py-1 rounded text-white font-medium transition focus:outline-none focus:ring-2 focus:ring-white ${
+                page <= 1
+                  ? 'bg-blue-400 cursor-not-allowed'
+                  : 'bg-blue-800 hover:bg-blue-700'
+              }`}
+            >
+              Previous
+            </button>
+
+            <span className="text-white text-sm">
+              Page {page} of {saTotalPages}
+            </span>
+
+            <button
+              onClick={handleNext}
+              disabled={page >= saTotalPages}
+              className={`px-3 py-1 rounded text-white font-medium transition focus:outline-none focus:ring-2 focus:ring-white ${
+                page >= saTotalPages
+                  ? 'bg-blue-400 cursor-not-allowed'
+                  : 'bg-blue-800 hover:bg-blue-700'
+              }`}
+            >
+              Next
+            </button>
+          </div>
+        )}
+      </div>
+    </AdminLayout>
+  );
+};
+
+export default SuperAdminPage;

--- a/src/pages/admin/users.tsx
+++ b/src/pages/admin/users.tsx
@@ -2,7 +2,7 @@ import { NextPage } from 'next';
 import { useEffect, useState } from 'react';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import api from '@/utils/api';
-import {fetchUsers,changeUserRole,deleteUser,User as AdminUser,} from '@/store/slices/adminSlice';
+import { fetchUsers, deleteUser, User as AdminUser } from '@/store/slices/adminSlice';
 import toast from 'react-hot-toast';
 import AdminLayout from '@/components/admin/AdminLayout';
 import Head from 'next/head';
@@ -13,200 +13,140 @@ import { Loader } from 'lucide-react';
 const AdminUsersPage: NextPage = () => {
 
   const dispatch = useAppDispatch();
-  const { users, loading, error, usersPage, usersTotalPages } = useAppSelector(
-    (state) => state.admin
-  );
-
-  const [page, setPage] = useState<number>(usersPage);
+  const { users, loading, error, } = useAppSelector((state) => state.admin);
+  const allFiltered = users.filter(u => u.role === 'TENANT' || u.role === 'LANDLORD');
   const [search, setSearch] = useState('');
   const [exporting, setExporting] = useState(false);
-  const [changingRoleIds, setChangingRoleIds] = useState<Record<string, boolean>>({});
   const [deletingIds, setDeletingIds] = useState<Record<string, boolean>>({});
-
   const limit = 5;
+  const [page, setPage] = useState(1);
+  const totalPages = Math.ceil(allFiltered.length / limit);
+  const pageData = allFiltered.slice((page - 1) * limit, page * limit);
 
   useEffect(() => {
     const token = localStorage.getItem('token') || '';
     connectSocket(token);
-
-    const handleNewUser = (newUser: AdminUser) => {
+    const handleNew = (newUser: AdminUser) => {
       toast(`New user joined: ${newUser.name}`, { icon: '👤' });
     };
-
-    socket.on('admin:newUser', handleNewUser);
-    return () => {
-      socket.off('admin:newUser', handleNewUser);
-    };
+    socket.on('admin:newUser', handleNew);
+    return () => { socket.off('admin:newUser', handleNew); };
   }, []);
 
   useEffect(() => {
-    dispatch(fetchUsers({ page, limit, search }));
-  }, [dispatch, page, search]);
+    dispatch(fetchUsers({ page: 1, limit: 1000, search }));
+  }, [dispatch, search]);
 
   const debouncedSearch = debounce((...args: unknown[]) => {
-    const value = args[0] as string;
+    const val = String(args[0] || '');
     setPage(1);
-    setSearch(value);
+    setSearch(val);
   }, 500);
 
   const handleExport = async () => {
     setExporting(true);
     try {
-      const response = await api.get('api/admin/users/export', {
-        responseType: 'blob',
-      });
-      const blob = new Blob([response.data], { type: response.headers['content-type'] });
-      const url = window.URL.createObjectURL(blob);
+      const res = await api.get('api/admin/users/export', { responseType: 'blob' });
+      const blob = new Blob([res.data], { type: res.headers['content-type'] });
+      const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
-      a.href = url;
-      a.download = 'rentify-users.xlsx';
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      window.URL.revokeObjectURL(url);
-
-      toast.success('Users exported successfully');
+      a.href = url; a.download = 'rentify-users.xlsx';
+      document.body.appendChild(a); a.click(); a.remove();
+      URL.revokeObjectURL(url);
+      toast.success('Exported!');
     } catch {
-      toast.error('Failed to export users: ');
+      toast.error('Export failed');
     } finally {
       setExporting(false);
     }
   };
 
-  const handleRoleChange = async (userId: string, newRole: AdminUser['role']) => {
-    setChangingRoleIds((m) => ({ ...m, [userId]: true }));
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete this user?')) return;
+    setDeletingIds(m => ({ ...m, [id]: true }));
     try {
-      await dispatch(changeUserRole({ userId, role: newRole })).unwrap();
-      toast.success('User role updated');
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      toast.error('Could not change role: ' + msg);
+      await dispatch(deleteUser(id)).unwrap();
+      toast.success('Deleted');
+    } catch{
+      toast.error('Delete failed: ');
     } finally {
-      setChangingRoleIds((m) => {
-        const next = { ...m };
-        delete next[userId];
-        return next;
-      });
+      setDeletingIds(m => { const next = { ...m }; delete next[id]; return next; });
     }
-  };
-
-  const handleDeleteUser = async (userId: string) => {
-    setDeletingIds((m) => ({ ...m, [userId]: true }));
-    try {
-      await dispatch(deleteUser(userId)).unwrap();
-      toast.success('User deleted');
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      toast.error('Could not delete user: ' + msg);
-    } finally {
-      setDeletingIds((m) => {
-        const next = { ...m };
-        delete next[userId];
-        return next;
-      });
-    }
-  };
-
-  const handlePrev = () => {
-    if (page > 1) setPage(page - 1);
-  };
-
-  const handleNext = () => {
-    if (page < usersTotalPages) setPage(page + 1);
   };
 
   return (
     <AdminLayout>
       <Head>
         <title>Rentify | Manage Users</title>
-        <meta
-          name="description"
-          content="Admin page to manage users for Rentify, including real-time updates."
-        />
       </Head>
-
       <div className="flex flex-col space-y-6 px-4 sm:px-6 lg:px-8">
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between p-4 bg-blue-600 rounded-lg space-y-4 sm:space-y-0">
-          <h1 className="text-xl sm:text-2xl font-bold text-white">Manage Users</h1>
-
-          <div className="flex flex-col sm:flex-row items-stretch sm:items-center space-y-2 sm:space-y-0 sm:space-x-2 w-full sm:w-auto">
+        <div className="flex flex-col sm:flex-row justify-between items-center p-4 bg-blue-600 rounded-lg">
+          <h1 className="text-white text-2xl font-bold">Manage Users</h1>
+          <div className="flex gap-2 w-full sm:w-auto">
             <input
               type="text"
-              placeholder="Search by name or email..."
-              onChange={(e) => debouncedSearch(e.target.value)}
-              className="flex-grow px-3 py-2 rounded border border-gray-300 focus:ring-2 focus:ring-blue-400 focus:outline-none w-full sm:w-64"
+              placeholder="Search name or email…"
+              className="flex-grow px-3 py-2 rounded border"
+              onChange={e => debouncedSearch(e.target.value)}
             />
-
             <button
               onClick={handleExport}
-              disabled={exporting || users.length === 0}
-              aria-busy={exporting}
-              className={`flex justify-center items-center px-4 py-2 rounded text-white transition w-full sm:w-auto ${
-                exporting || users.length === 0
+              disabled={exporting || allFiltered.length === 0}
+              className={`px-4 py-2 text-white rounded ${
+                exporting || allFiltered.length === 0
                   ? 'bg-green-400 cursor-not-allowed'
                   : 'bg-green-600 hover:bg-green-700'
               }`}
             >
-              {exporting ? <Loader className="animate-spin mr-2 h-4 w-4" /> : null}
-              {exporting ? 'Exporting…' : 'Export Users'}
+              {exporting ? <Loader className="animate-spin mr-2 h-4 w-4" /> : 'Export'}
             </button>
           </div>
         </div>
 
-        {loading && (
+        {loading ? (
           <div className="flex justify-center py-10">
             <Loader className="animate-spin h-12 w-12 text-blue-600" />
           </div>
-        )}
-
-        {error && <p className="text-red-500">Error loading users: {error}</p>}
-        {!loading && !error && users.length === 0 && (
+        ) : error ? (
+          <p className="text-red-500">{error}</p>
+        ) : allFiltered.length === 0 ? (
           <p className="text-gray-600">No users found.</p>
-        )}
-
-        {!loading && !error && users.length > 0 && (
+        ) : (
           <>
             <div className="overflow-x-auto rounded-lg shadow-sm">
-              <table className="min-w-full divide-y divide-gray-200 bg-white text-gray-900">
+              <table className="min-w-full bg-white divide-y divide-gray-200">
                 <thead className="bg-blue-600 sticky top-0">
                   <tr>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-white">Name</th>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-white hidden md:table-cell">Email</th>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-white">Role</th>
-                    <th className="px-4 py-2 text-left text-sm font-medium text-white">Joined</th>
-                    <th className="px-4 py-2 text-center text-sm font-medium text-white">Actions</th>
+                    <th className="px-4 py-2 text-white text-left">Name</th>
+                    <th className="px-4 py-2 text-white text-left hidden md:table-cell">Email</th>
+                    <th className="px-4 py-2 text-white text-left">Role</th>
+                    <th className="px-4 py-2 text-white text-left">Joined</th>
+                    <th className="px-4 py-2 text-white text-center">Actions</th>
                   </tr>
                 </thead>
                 <tbody className="divide-y divide-gray-200">
-                  {users.map((u) => (
+                  {pageData.map(u => (
                     <tr key={u.id} className="hover:bg-gray-50">
-                      <td className="px-4 py-3 whitespace-nowrap text-sm font-medium">{u.name}</td>
-                      <td className="px-4 py-3 whitespace-nowrap text-sm hidden md:table-cell">
-                        <a href={`mailto:${u.email}`} className="text-blue-600 hover:underline">{u.email}</a>
+                      <td className="px-4 py-3">{u.name}</td>
+                      <td className="px-4 py-3 hidden md:table-cell">
+                        <a href={`mailto:${u.email}`} className="text-blue-600">
+                          {u.email}
+                        </a>
                       </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-sm">
-                        <select
-                          value={u.role}
-                          onChange={(e) => handleRoleChange(u.id, e.target.value as AdminUser['role'])}
-                          disabled={changingRoleIds[u.id]}
-                          className="px-2 py-1 rounded border border-gray-300 focus:outline-none focus:ring-2 focus:ring-blue-500 bg-gray-50"
-                        >
-                          <option value="TENANT">Tenant</option>
-                          <option value="LANDLORD">Landlord</option>
-                          <option value="ADMIN">Admin</option>
-                        </select>
-                      </td>
-                      <td className="px-4 py-3 whitespace-nowrap text-sm">{new Date(u.createdAt).toLocaleDateString()}</td>
-                      <td className="px-4 py-3 whitespace-nowrap text-center text-sm space-x-1">
+                      <td className="px-4 py-3">{u.role}</td>
+                      <td className="px-4 py-3">{new Date(u.createdAt).toLocaleDateString()}</td>
+                      <td className="px-4 py-3 text-center">
                         <button
-                          onClick={() => handleDeleteUser(u.id)}
+                          onClick={() => handleDelete(u.id)}
                           disabled={deletingIds[u.id]}
-                          className={`px-3 py-1 rounded text-white font-medium transition focus:outline-none focus:ring-2 focus:ring-red-500 ${
-                            deletingIds[u.id]
-                              ? 'bg-red-200 cursor-not-allowed'
-                              : 'bg-red-500 hover:bg-red-600'
+                          className={`px-3 py-1 text-white rounded ${
+                            deletingIds[u.id] ? 'bg-red-200' : 'bg-red-600 hover:bg-red-700'
                           }`}
-                        >{deletingIds[u.id] ? <Loader className="animate-spin h-4 w-4 mx-auto" /> : 'Delete'}</button>
+                        >
+                          {deletingIds[u.id]
+                            ? <Loader className="animate-spin h-4 w-4 mx-auto" />
+                            : 'Delete'}
+                        </button>
                       </td>
                     </tr>
                   ))}
@@ -214,30 +154,24 @@ const AdminUsersPage: NextPage = () => {
               </table>
             </div>
 
-            <div className="flex flex-col sm:flex-row items-center justify-between px-4 py-3 bg-blue-600 rounded-b-lg space-y-2 sm:space-y-0">
+            <div className="flex justify-between items-center px-4 py-3 bg-blue-600 rounded-b-lg">
               <button
-                onClick={handlePrev}
-                disabled={page <= 1}
-                className={`px-3 py-1 rounded text-white font-medium transition focus:outline-none focus:ring-2 focus:ring-white ${
-                  page <= 1
-                    ? 'bg-blue-400 cursor-not-allowed'
-                    : 'bg-blue-800 hover:bg-blue-700'
+                onClick={() => setPage(p => Math.max(1, p - 1))}
+                disabled={page === 1}
+                className={`px-3 py-1 text-white rounded ${
+                  page === 1 ? 'bg-blue-400' : 'bg-blue-800 hover:bg-blue-700'
                 }`}
               >
                 Previous
               </button>
-
-              <span className="text-white text-sm">
-                Page {page} of {usersTotalPages}
+              <span className="text-white">
+                Page {page} of {totalPages}
               </span>
-
               <button
-                onClick={handleNext}
-                disabled={page >= usersTotalPages}
-                className={`px-3 py-1 rounded text-white font-medium transition focus:outline-none focus:ring-2 focus:ring-white ${
-                  page >= usersTotalPages
-                    ? 'bg-blue-400 cursor-not-allowed'
-                    : 'bg-blue-800 hover:bg-blue-700'
+                onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+                disabled={page === totalPages}
+                className={`px-3 py-1 text-white rounded ${
+                  page === totalPages ? 'bg-blue-400' : 'bg-blue-800 hover:bg-blue-700'
                 }`}
               >
                 Next
@@ -251,3 +185,6 @@ const AdminUsersPage: NextPage = () => {
 };
 
 export default AdminUsersPage;
+
+
+

--- a/src/pages/auth/login.tsx
+++ b/src/pages/auth/login.tsx
@@ -31,7 +31,7 @@ export default function LoginPage() {
 
   useEffect(() => {
     if (!user) return;
-    if (user.role === 'ADMIN') {
+    if (user.role === 'ADMIN' || user.role === 'SUPER_ADMIN') {
       router.push('/admin');
     }else {
       const destination = redirect ? decodeURIComponent(redirect) : '/properties';

--- a/src/pages/become-landlord.tsx
+++ b/src/pages/become-landlord.tsx
@@ -11,6 +11,7 @@ import Link from 'next/link';
 import Image from 'next/image';
 
 const BecomeLandlordPage: NextPage = () => {
+  
   const dispatch = useAppDispatch();
   const router = useRouter();
   const { theme } = useContext(ThemeContext)!;

--- a/src/pages/properties/[id].tsx
+++ b/src/pages/properties/[id].tsx
@@ -177,10 +177,8 @@ const PropertyDetailPage: React.FC = () => {
                   </div>
                   {isPropLandlord && (
                     <div className="flex space-x-2">
-                      <Link href={`/properties/${current.id}/edit`} passHref>
-                        <a className="px-4 py-2 bg-yellow-500 text-white rounded-lg hover:bg-yellow-600 transition">
+                      <Link href={`/properties/${current.id}/edit`} passHref className="px-4 py-2 bg-yellow-500 text-white rounded-lg hover:bg-yellow-600 transition">
                           Edit
-                        </a>
                       </Link>
                       <button
                         onClick={handleDelete}

--- a/src/store/slices/adminSlice.ts
+++ b/src/store/slices/adminSlice.ts
@@ -1,4 +1,4 @@
-import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
+import { createSlice, createAsyncThunk} from '@reduxjs/toolkit';
 import axios from 'axios';
 import api from '../../utils/api';
 
@@ -11,15 +11,6 @@ export interface Property {
   status: 'PENDING' | 'APPROVED' | 'REJECTED';
   rejectionReason?: string | null;
   createdAt: string;
-}
-
-export interface User {
-  id: string;
-  name: string;
-  email: string;
-  role: 'TENANT' | 'LANDLORD' | 'ADMIN';
-  createdAt: string;      
-  profilePhoto?: string;  
 }
 
 
@@ -52,10 +43,19 @@ export interface Metrics {
   totalRevenue: number;
 }
 
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: 'TENANT' | 'LANDLORD' | 'ADMIN' | 'SUPER_ADMIN';
+  createdAt: string;
+  profilePhoto?: string;
+}
+
+export interface UsersPaginationMeta { totalUsers: number; page: number; limit: number; totalPages: number; }
 export interface PropertiesPaginationMeta { totalProperties: number; page: number; limit: number; totalPages: number; }
-export interface UsersPaginationMeta      { totalUsers: number;      page: number; limit: number; totalPages: number; }
-export interface BookingsPaginationMeta   { totalBookings: number;   page: number; limit: number; totalPages: number; }
-export interface ReviewsPaginationMeta    { totalReviews: number;    page: number; limit: number; totalPages: number; }
+export interface BookingsPaginationMeta { totalBookings: number; page: number; limit: number; totalPages: number; }
+export interface ReviewsPaginationMeta { totalReviews: number; page: number; limit: number; totalPages: number; }
 
 interface AdminState {
   users: User[];
@@ -83,6 +83,13 @@ interface AdminState {
   reviewsTotalPages: number;
 
   metrics: Metrics | null;
+
+  admins: User[];
+  saPage: number;
+  saLimit: number;
+  saTotal: number;
+  saTotalPages: number;
+
   loading: boolean;
   error: string | null;
 }
@@ -93,6 +100,7 @@ const initialState: AdminState = {
   bookings: [], bookingsPage: 1, bookingsLimit: 10, bookingsTotal: 0, bookingsTotalPages: 1,
   reviews: [], reviewsPage: 1, reviewsLimit: 10, reviewsTotal: 0, reviewsTotalPages: 1,
   metrics: null,
+  admins: [], saPage: 1, saLimit: 10, saTotal: 0, saTotalPages: 1,
   loading: false,
   error: null,
 };
@@ -334,110 +342,212 @@ export const fetchMetrics = createAsyncThunk<
   }
 });
 
+export const fetchAdmins = createAsyncThunk<
+  { data: User[]; meta: UsersPaginationMeta },
+  { page: number; limit: number },
+  { rejectValue: string }
+>(
+  'admin/fetchSuperAdmins',
+  async ({ page, limit }, { rejectWithValue }) => {
+    try {
+      const token = localStorage.getItem('token');
+      const { data } = await api.get(
+        `api/super-admin/admins?page=${page}&limit=${limit}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      return data;
+    } catch (err: unknown) {
+      const msg = axios.isAxiosError(err)
+        ? err.response?.data?.error || err.message
+        : err instanceof Error
+        ? err.message
+        : 'Failed to load admins';
+      return rejectWithValue(msg);
+    }
+  }
+);
+
+export const createAdmin = createAsyncThunk<
+  { user: User; token: string },
+  { email: string; name: string; password: string },
+  { rejectValue: string }
+>(
+  'admin/createAdmin',
+  async (payload, { rejectWithValue }) => {
+    try {
+      const token = localStorage.getItem('token');
+      const { data } = await api.post(
+        `api/super-admin/admins`,
+        payload,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      return data;
+    } catch (err: unknown) {
+      const msg = axios.isAxiosError(err)
+        ? err.response?.data?.error || err.message
+        : err instanceof Error
+        ? err.message
+        : 'Failed to create admin';
+      return rejectWithValue(msg);
+    }
+  }
+);
+
+export const deleteAdmin = createAsyncThunk<
+  string,
+  string,
+  { rejectValue: string }
+>(
+  'admin/deleteAdmin',
+  async (id, { rejectWithValue }) => {
+    try {
+      const token = localStorage.getItem('token');
+      await api.delete(
+        `api/super-admin/admins/${id}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      return id;
+    } catch (err: unknown) {
+      const msg = axios.isAxiosError(err)
+        ? err.response?.data?.error || err.message
+        : err instanceof Error
+        ? err.message
+        : 'Failed to delete admin';
+      return rejectWithValue(msg);
+    }
+  }
+);
+
 const adminSlice = createSlice({
   name: 'admin',
   initialState,
   reducers: {
-    addProperty(state, action: PayloadAction<Property>) {
-      state.properties.unshift(action.payload);
-      state.propertiesTotal++;
-      state.propertiesTotalPages = Math.ceil(state.propertiesTotal / state.propertiesLimit);
-    },
-    updateProperty(state, action: PayloadAction<Property>) {
-      const idx = state.properties.findIndex(p => p.id === action.payload.id);
-      if (idx >= 0) state.properties[idx] = action.payload;
-    },
     clearAdminError(state) {
       state.error = null;
     },
   },
   extraReducers: (builder) => {
     builder
-      .addCase(fetchUsers.pending, (s) => { s.loading = true; s.error = null; })
-      .addCase(fetchUsers.fulfilled, (s, { payload }) => {
-        s.loading = false;
-        s.users = payload.data;
-        s.usersPage = payload.meta.page;
-        s.usersLimit = payload.meta.limit;
-        s.usersTotal = payload.meta.totalUsers;
-        s.usersTotalPages = payload.meta.totalPages;
+      .addCase(fetchUsers.pending, (state) => {
+        state.loading = true;
+        state.error = null;
       })
-      .addCase(fetchUsers.rejected, (s, { payload }) => {
-        s.loading = false;
-        s.error = typeof payload === 'string' ? payload : 'Failed to load users';
+      .addCase(fetchUsers.fulfilled, (state, { payload }) => {
+        state.loading = false;
+        state.users = payload.data;
+        state.usersPage = payload.meta.page;
+        state.usersLimit = payload.meta.limit;
+        state.usersTotal = payload.meta.totalUsers;
+        state.usersTotalPages = payload.meta.totalPages;
       })
+      .addCase(fetchUsers.rejected, (state, { payload }) => {
+        state.loading = false;
+        state.error = typeof payload === 'string' ? payload : 'Failed to load';
+      });
     builder
-      .addCase(changeUserRole.pending, (s) => { s.loading = true; s.error = null; })
-      .addCase(changeUserRole.fulfilled, (s, { payload }) => {
-        s.loading = false;
-        const idx = s.users.findIndex(u => u.id === payload.user.id);
-        if (idx >= 0) s.users[idx] = payload.user;
+      .addCase(changeUserRole.pending, (state) => {
+        state.loading = true;
+        state.error = null;
       })
-      .addCase(changeUserRole.rejected, (s, { payload }) => {
-        s.loading = false;
-        s.error = payload || 'Failed to update role';
+      .addCase(changeUserRole.fulfilled, (state, { payload }) => {
+        state.loading = false;
+        const idx = state.users.findIndex(u => u.id === payload.user.id);
+        if (idx >= 0) state.users[idx] = payload.user;
       })
+      .addCase(changeUserRole.rejected, (state, { payload }) => {
+        state.loading = false;
+        state.error = payload ?? 'Failed to update role';
+      });
     builder
-      .addCase(deleteUser.pending, (s) => { s.loading = true; s.error = null; })
-      .addCase(deleteUser.fulfilled, (s, { payload }) => {
-        s.loading = false;
-        s.users = s.users.filter(u => u.id !== payload);
-        s.usersTotal--;
-        s.usersTotalPages = Math.ceil(s.usersTotal / s.usersLimit);
+      .addCase(deleteUser.pending, (state) => {
+        state.loading = true;
+        state.error = null;
       })
-      .addCase(deleteUser.rejected, (s, { payload }) => {
-        s.loading = false;
-        s.error = payload || 'Failed to delete user';
+      .addCase(deleteUser.fulfilled, (state, { payload: userId }) => {
+        state.loading = false;
+        state.users = state.users.filter(u => u.id !== userId);
+        state.usersTotal--;
+        state.usersTotalPages = Math.ceil(state.usersTotal / state.usersLimit);
       })
+      .addCase(deleteUser.rejected, (state, { payload }) => {
+        state.loading = false;
+        state.error = payload ?? 'Failed to delete user';
+      });
+
+    // ─── fetchProperties ───
     builder
-      .addCase(fetchProperties.pending, (s) => { s.loading = true; s.error = null; })
-      .addCase(fetchProperties.fulfilled, (s, { payload }) => {
-        s.loading = false;
-        s.properties = payload.data;
-        s.propertiesPage = payload.meta.page;
-        s.propertiesLimit = payload.meta.limit;
-        s.propertiesTotal = payload.meta.totalProperties;
-        s.propertiesTotalPages = payload.meta.totalPages;
+      .addCase(fetchProperties.pending, (state) => {
+        state.loading = true;
+        state.error = null;
       })
-      .addCase(fetchProperties.rejected, (s, { payload }) => {
-        s.loading = false;
-        s.error = payload || 'Failed to load properties';
+      .addCase(fetchProperties.fulfilled, (state, { payload }) => {
+        state.loading = false;
+        state.properties = payload.data;
+        state.propertiesPage = payload.meta.page;
+        state.propertiesLimit = payload.meta.limit;
+        state.propertiesTotal = payload.meta.totalProperties;
+        state.propertiesTotalPages = payload.meta.totalPages;
       })
+      .addCase(fetchProperties.rejected, (state, { payload }) => {
+        state.loading = false;
+        state.error = payload ?? 'Failed to load properties';
+      });
+
+    // ─── approveProperty ───
     builder
-      .addCase(approveProperty.pending, (s) => { s.loading = true; s.error = null; })
-      .addCase(approveProperty.fulfilled, (s, { payload }) => {
-        s.loading = false;
-        const idx = s.properties.findIndex(p => p.id === payload.id);
-        if (idx >= 0) s.properties[idx] = payload;
+      .addCase(approveProperty.pending, (state) => {
+        state.loading = true;
+        state.error = null;
       })
-      .addCase(approveProperty.rejected, (s, { payload }) => {
-        s.loading = false;
-        s.error = payload || 'Failed to approve property';
+      .addCase(approveProperty.fulfilled, (state, { payload }) => {
+        state.loading = false;
+        const idx = state.properties.findIndex(p => p.id === payload.id);
+        if (idx >= 0) state.properties[idx] = payload;
       })
+      .addCase(approveProperty.rejected, (state, { payload }) => {
+        state.loading = false;
+        state.error = payload ?? 'Failed to approve property';
+      });
+
+    // ─── rejectProperty ───
     builder
-      .addCase(rejectProperty.pending, (s) => { s.loading = true; s.error = null; })
-      .addCase(rejectProperty.fulfilled, (s, { payload }) => {
-        s.loading = false;
-        const idx = s.properties.findIndex(p => p.id === payload.id);
-        if (idx >= 0) s.properties[idx] = payload;
+      .addCase(rejectProperty.pending, (state) => {
+        state.loading = true;
+        state.error = null;
       })
-      .addCase(rejectProperty.rejected, (s, { payload }) => {
-        s.loading = false;
-        s.error = payload || 'Failed to reject property';
+      .addCase(rejectProperty.fulfilled, (state, { payload }) => {
+        state.loading = false;
+        const idx = state.properties.findIndex(p => p.id === payload.id);
+        if (idx >= 0) state.properties[idx] = payload;
       })
+      .addCase(rejectProperty.rejected, (state, { payload }) => {
+        state.loading = false;
+        state.error = payload ?? 'Failed to reject property';
+      });
+
+    // ─── deletePropertyByAdmin ───
     builder
-      .addCase(deletePropertyByAdmin.pending, (s) => { s.loading = true; s.error = null; })
-      .addCase(deletePropertyByAdmin.fulfilled, (s, { payload }) => {
-        s.loading = false;
-        s.properties = s.properties.filter(p => p.id !== payload);
-        s.propertiesTotal--;
-        s.propertiesTotalPages = Math.ceil(s.propertiesTotal / s.propertiesLimit);
+      .addCase(deletePropertyByAdmin.pending, (state) => {
+        state.loading = true;
+        state.error = null;
       })
-      .addCase(deletePropertyByAdmin.rejected, (s, { payload }) => {
-        s.loading = false;
-        s.error = payload || 'Failed to delete property';
+      .addCase(deletePropertyByAdmin.fulfilled, (state, { payload: propertyId }) => {
+        state.loading = false;
+        state.properties = state.properties.filter(p => p.id !== propertyId);
+        state.propertiesTotal--;
+        state.propertiesTotalPages = Math.ceil(state.propertiesTotal / state.propertiesLimit);
       })
-      .addCase(fetchBookings.pending, state => { state.loading = true; state.error = null; })
+      .addCase(deletePropertyByAdmin.rejected, (state, { payload }) => {
+        state.loading = false;
+        state.error = payload ?? 'Failed to delete property';
+      });
+
+    // ─── fetchBookings ───
+    builder
+      .addCase(fetchBookings.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
       .addCase(fetchBookings.fulfilled, (state, { payload }) => {
         state.loading = false;
         state.bookings = payload.data;
@@ -448,10 +558,15 @@ const adminSlice = createSlice({
       })
       .addCase(fetchBookings.rejected, (state, { payload }) => {
         state.loading = false;
-        state.error = payload || 'Failed to load bookings';
-      })
+        state.error = payload ?? 'Failed to load bookings';
+      });
 
-      .addCase(updateBookingStatus.pending, state => { state.loading = true; state.error = null; })
+    // ─── updateBookingStatus ───
+    builder
+      .addCase(updateBookingStatus.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
       .addCase(updateBookingStatus.fulfilled, (state, { payload }) => {
         state.loading = false;
         const idx = state.bookings.findIndex(b => b.id === payload.id);
@@ -459,9 +574,15 @@ const adminSlice = createSlice({
       })
       .addCase(updateBookingStatus.rejected, (state, { payload }) => {
         state.loading = false;
-        state.error = payload || 'Failed to update booking';
+        state.error = payload ?? 'Failed to update booking status';
+      });
+
+    // ─── fetchReviews ───
+    builder
+      .addCase(fetchReviews.pending, (state) => {
+        state.loading = true;
+        state.error = null;
       })
-      .addCase(fetchReviews.pending, state => { state.loading = true; state.error = null; })
       .addCase(fetchReviews.fulfilled, (state, { payload }) => {
         state.loading = false;
         state.reviews = payload.data;
@@ -472,32 +593,94 @@ const adminSlice = createSlice({
       })
       .addCase(fetchReviews.rejected, (state, { payload }) => {
         state.loading = false;
-        state.error = payload || 'Failed to load reviews';
+        state.error = payload ?? 'Failed to load reviews';
+      });
+
+    // ─── deleteReview ───
+    builder
+      .addCase(deleteReview.pending, (state) => {
+        state.loading = true;
+        state.error = null;
       })
-      .addCase(deleteReview.pending, state => { state.loading = true; state.error = null; })
-      .addCase(deleteReview.fulfilled, (state, { payload }) => {
+      .addCase(deleteReview.fulfilled, (state, { payload: reviewId }) => {
         state.loading = false;
-        state.reviews = state.reviews.filter(r => r.id !== payload);
+        state.reviews = state.reviews.filter(r => r.id !== reviewId);
         state.reviewsTotal--;
         state.reviewsTotalPages = Math.ceil(state.reviewsTotal / state.reviewsLimit);
       })
       .addCase(deleteReview.rejected, (state, { payload }) => {
         state.loading = false;
-        state.error = payload || 'Failed to delete review';
+        state.error = payload ?? 'Failed to delete review';
+      });
+
+    // ─── fetchMetrics ───
+    builder
+      .addCase(fetchMetrics.pending, (state) => {
+        state.loading = true;
+        state.error = null;
       })
-      .addCase(fetchMetrics.pending, state => { state.loading = true; state.error = null; })
       .addCase(fetchMetrics.fulfilled, (state, { payload }) => {
         state.loading = false;
         state.metrics = payload;
       })
       .addCase(fetchMetrics.rejected, (state, { payload }) => {
         state.loading = false;
-        state.error = payload || 'Failed to load metrics';
+        state.error = payload ?? 'Failed to load metrics';
+      });
+
+    // ─── fetchSuperAdmins ───
+    builder
+      .addCase(fetchAdmins.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(fetchAdmins.fulfilled, (state, { payload }) => {
+        state.loading = false;
+        state.admins = payload.data;
+        state.saPage = payload.meta.page;
+        state.saLimit = payload.meta.limit;
+        state.saTotal = payload.meta.totalUsers;
+        state.saTotalPages = payload.meta.totalPages;
+      })
+      .addCase(fetchAdmins.rejected, (state, { payload }) => {
+        state.loading = false;
+        state.error = payload ?? 'Failed to load admins';
+      });
+
+    // ─── createAdmin ───
+    builder
+      .addCase(createAdmin.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(createAdmin.fulfilled, (state, { payload }) => {
+        state.loading = false;
+        state.admins.unshift(payload.user);
+        state.saTotal++;
+        state.saTotalPages = Math.ceil(state.saTotal / state.saLimit);
+      })
+      .addCase(createAdmin.rejected, (state, { payload }) => {
+        state.loading = false;
+        state.error = payload ?? 'Failed to create admin';
+      });
+
+    // ─── deleteAdmin ───
+    builder
+      .addCase(deleteAdmin.pending, (state) => {
+        state.loading = true;
+        state.error = null;
+      })
+      .addCase(deleteAdmin.fulfilled, (state, { payload: id }) => {
+        state.loading = false;
+        state.admins = state.admins.filter(a => a.id !== id);
+        state.saTotal--;
+        state.saTotalPages = Math.ceil(state.saTotal / state.saLimit);
+      })
+      .addCase(deleteAdmin.rejected, (state, { payload }) => {
+        state.loading = false;
+        state.error = payload ?? 'Failed to delete admin';
       });
   }
 });
-
-export const { addProperty, updateProperty, clearAdminError } = adminSlice.actions;
+export const { clearAdminError } = adminSlice.actions;
 export default adminSlice.reducer;
-
-

--- a/src/store/slices/authSlice.ts
+++ b/src/store/slices/authSlice.ts
@@ -3,7 +3,7 @@ import axios from 'axios';
 import api from '@/utils/api';
 import { changeUserRole } from './adminSlice';
 
-type Role = 'TENANT' | 'LANDLORD' | 'ADMIN';
+type Role = 'TENANT' | 'LANDLORD' | 'ADMIN' | 'SUPER_ADMIN';
 
 export interface User {
   id: string;


### PR DESCRIPTION
- Introduce Super‑Admin page (listing, pagination, create & delete admins)
- Update AdminLayout & SideBar to include Super‑Admin link
- Style Super‑Admin page consistent with Manage Users page
- Refactor Users page to restrict to Tenant/Landlord roles
- Enhance Properties, Bookings, Landlord Requests pages with modals and inline details
- Adjust login, profile, and become‑landlord pages for role flows
- Extend adminSlice to handle super‑admin thunks and state